### PR TITLE
[IMP] adjust FormField float label style

### DIFF
--- a/components-pro/field/style/mixin.less
+++ b/components-pro/field/style/mixin.less
@@ -59,6 +59,8 @@
   &-float-label .@{field-label-prefix-cls},
   &-float-label&-focused .@{field-label-prefix-cls},
   &-float-label &:-webkit-autofill + .@{field-label-prefix-cls}-wrapper .@{field-label-prefix-cls} {
+    font-size: .15rem; // 15 * 0.8(缩放比例) = 12(目标值)
+    font-weight: 500;
     transform: scaleY(.8);
   }
   &-float-label & {
@@ -82,6 +84,8 @@
         transform: none;
       }
       transform: none;
+      font-size: inherit;
+      font-weight: auto;
     }
   }
   &-float-label & > ul {

--- a/components-pro/text-field/style/mixin.less
+++ b/components-pro/text-field/style/mixin.less
@@ -381,7 +381,7 @@
     bottom: 0;
     left: 0;
     border: @border-width-base @border-style-base @input-border-color;
-    border-radius: .04rem;
+    border-radius: .05rem;
   }
   &-float-label&-focused:before,
   &-float-label&-invalid:before {

--- a/components-pro/validator/style/index.less
+++ b/components-pro/validator/style/index.less
@@ -2,6 +2,8 @@
 @import "../../../components/style/mixins/index";
 
 .@{c7n-pro-prefix}-validation-message {
+  padding-left: .10rem;
+  font-size: .12rem;
   color: @error-color;
   white-space: nowrap;
   max-width: unset;


### PR DESCRIPTION
- 输入框正常高度 height:36px
- 左上角标签 font-size:12px;font-weight:500
- 边框 
  - 正常状态 border: 1px solid rgba(0, 0, 0, 0.2) 
  - 聚焦状态 border: 2px solid #3f51b5 
  - 输入报错状态 border: 2px solid #d50000;font-size:12px;color:#d50000,
- 提示文字与输入文字左对齐 padding-left:10px
- 圆角 border-radius:5px