### PR TITLE
[IMP] update Tabs inactive nav-tab font color

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -29,6 +29,7 @@ timeline: true
 - 💄 `<pro>Popup`: upgrade the `z-index` style.
 - 💄 `SelectBox`: Update the style(with 'floatLabel' layout).
 - 💄 `TextArea`: Update the style.
+- 💄 `Tabs`: Update the style.
 - 🐞 `<pro>FormField`: Fix the problem when the label is ReactNode.
 
 ## 0.7.6

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -29,6 +29,7 @@ timeline: true
 - 💄 `<pro>Popup`: 提升样式z-index。
 - 💄 `SelectBox`: 更新样式（浮动标签状态下）。
 - 💄 `TexaArea`: 更新样式。
+- 💄 `Tabs`: 更新样式。
 - 🐞 `<pro>FormField`: 修复label为ReactNode时的问题。
 
 ## 0.7.6

--- a/components/style/themes/default.less
+++ b/components/style/themes/default.less
@@ -456,6 +456,7 @@
 @tab-vertical-padding: .08rem .24rem;
 @tab-scrolling-size: .32rem;
 @tab-highlight-color: @primary-color;
+@tab-normal-color: rgba(0, 0, 0, .87);
 @tab-hover-color: @primary-5;
 @tab-active-color: @primary-7;
 

--- a/components/tabs/style/index.less
+++ b/components/tabs/style/index.less
@@ -176,6 +176,7 @@
       padding: @tab-horizontal-padding;
       box-sizing: border-box;
       position: relative;
+      color: @tab-normal-color;
 
       &:last-child {
         margin-right: 0;


### PR DESCRIPTION
调整了Tabs组件中，非激活Tab的字体颜色为`rgb(0, 0, 0, .87)`
![image](https://user-images.githubusercontent.com/32608999/61621376-71c79f80-aca5-11e9-87d8-e3359a0bd4fe.png)
