### PR TITLE
[IMP] Optimize the table style, fix the problem of the table border

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -18,6 +18,7 @@ timeline: true
 - 🌟 `<pro>Table.Filter`: Optimize the position of the filter placeholder and cursor, and adjust the filter bar height to 40px.
 - 🌟 `<pro>Table`: The temporarily deleted line is displayed as disabled and reset when the submission fails.
 - 🌟 `<pro>DataSet.Record`: Added save and restore methods.
+- 🐞 `<pro>Table`: Fixed a problem where there would be no border between the non-fixed and fixed columns of the Table.
 - 🐞 `<pro>Table`: Fix the row positioning problem with the up and down key of keyboard.
 - 🐞 `<pro>DataSet`: Fix the problem when dataKey is null.
 - 🐞 `<pro>DataSet`: Fixed an issue that export function can not be executed until the exportUrl property is set.

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,7 @@ timeline: true
 
 ---
 
+- 🌟 `<pro>Table.Filter`: Optimize the position of the filter placeholder and cursor, and adjust the filter bar height to 40px.
 - 🌟 `<pro>Table`: The temporarily deleted line is displayed as disabled and reset when the submission fails.
 - 🌟 `<pro>DataSet.Record`: Added save and restore methods.
 - 🐞 `<pro>Table`: Fix the row positioning problem with the up and down key of keyboard.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,7 @@ timeline: true
 
 ---
 
+- 🌟 `<pro>Table.Filter`: 优化过滤条placeholder文字与光标的位置，调整过滤条高度为40px。
 - 🌟 `<pro>Table`: 临时删除的行显示为禁用状态，提交失败时重置状态。
 - 🌟 `<pro>DataSet.Record`: 新增save和restore方法。
 - 🐞 `<pro>Table`: 修复键盘的上下键操作时行高亮定位问题。

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -18,6 +18,7 @@ timeline: true
 - 🌟 `<pro>Table.Filter`: 优化过滤条placeholder文字与光标的位置，调整过滤条高度为40px。
 - 🌟 `<pro>Table`: 临时删除的行显示为禁用状态，提交失败时重置状态。
 - 🌟 `<pro>DataSet.Record`: 新增save和restore方法。
+- 🐞 `<pro>Table`: 修复Table有Column的lock="right"的时候，非固定和固定列之间会没有border的问题。
 - 🐞 `<pro>Table`: 修复键盘的上下键操作时行高亮定位问题。
 - 🐞 `<pro>DataSet`: 修复dataKey为null时的问题。
 - 🐞 `<pro>DataSet`: 修复必须要设置exportUrl才能导出的问题。

--- a/components-pro/table/style/index.less
+++ b/components-pro/table/style/index.less
@@ -469,9 +469,10 @@
   }
 
   &-filter-select {
-    .input(.46rem, .65rem);
+    .input(.5rem, .65rem);
     padding-right: .65rem !important;
     padding-left: .46rem !important;
+    line-height: .35rem;
     border: none;
     border-top: @table-border !important;
     &-wrapper {

--- a/components-pro/table/style/index.less
+++ b/components-pro/table/style/index.less
@@ -194,6 +194,7 @@
     .@{table-prefix-cls}-cell,
     .@{table-prefix-cls}-cell[colspan] {
       border-right: @table-border;
+      border-left: @table-border;
       border-bottom: @table-border;
     }
     .@{table-prefix-cls}-cell-inner {


### PR DESCRIPTION
[FIX] <pro>Table: 修复Table有Column的lock="right"的时候，非固定和固定列之间会没有border的问题。
[IMP]<pro>Table.Filter: 优化过滤条placeholder文字与光标的位置，调整过滤条高度为40px。