### PR TITLE
[FIX] <pro> TableEditor: Fix the editor of the table in the modal, an…

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -19,6 +19,7 @@ timeline: true
 - 🐞 Fix the problem that the base component and pro component have the same name pre-variable conflict when fully relying on the style.
 - 🐞 `<pro>Lov`: Fix the problem that `valueField` and `textField` in lov configuration are invalid when `lovCode` is obtained through `dynamicProps`.
 - 🐞 `<pro>Select`: Fix the problem of no option when `lovCode` field's type is string.
+- 🐞 `<pro>TableEditor`: Fix the editor of the table in the `Modal`, and then change the window size, the positioning will be incorrect.
 
 ## 0.8.56
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -19,6 +19,7 @@ timeline: true
 - 🐞 修复全量依赖样式时基础组件和 pro 组件存在同名预变量冲突的问题。
 - 🐞 `<pro>Lov`: 修复通过 dynamicProps 获得 lovCode 时，lov 配置中的 valueField 和 textField 无效的问题。
 - 🐞 `<pro>Select`: 修复 lovCode 字段类型为 string 时无选项的问题。
+- 🐞 `<pro>TableEditor`: 修复表格的 editor 在弹框中，然后变更窗口大小，会定位不对的问题。
 
 ## 0.8.56
 

--- a/components-pro/table/TableEditor.tsx
+++ b/components-pro/table/TableEditor.tsx
@@ -37,6 +37,19 @@ export default class TableEditor extends Component<TableEditorProps> {
   currentEditorName?: string;
 
   @autobind
+  onWindowResize() {
+    this.forceUpdate();
+  }
+
+  componentDidMount() {
+    window.addEventListener('resize', this.onWindowResize);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.onWindowResize);
+  }
+
+  @autobind
   saveRef(node) {
     this.editor = node;
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18377378/74820169-86a00a80-533c-11ea-98b1-1d0c4e817890.png)
修复表格的editor在弹框中，然后变更窗口大小，会定位不对的问题。