### PR TITLE
[FIX] 修复CollapsePanel在typescript报错的bug

### DIFF
--- a/components/collapse/CollapsePanel.tsx
+++ b/components/collapse/CollapsePanel.tsx
@@ -13,7 +13,7 @@ export interface CollapsePanelProps {
   forceRender?: boolean;
 }
 
-export default function CollapsePanel(props: CollapsePanelProps) {
+const CollapsePanel: React.FC<CollapsePanelProps> = (props: CollapsePanelProps) => {
   const { prefixCls, className = '', showArrow = true } = props;
   const collapsePanelClassName = classNames(
     {
@@ -22,4 +22,6 @@ export default function CollapsePanel(props: CollapsePanelProps) {
     className,
   );
   return <RcCollapse.Panel {...props} className={collapsePanelClassName} />;
-}
+};
+
+export default CollapsePanel;


### PR DESCRIPTION
在typescript中，函数组件需要定义为`FunctionComponent`类型，避免在使用的时候出现参数类型不匹配的错误