### PR TITLE
[FIX] <pro>Table: Modified the judgment mechanism of `useMouseBatchCh…

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -22,6 +22,7 @@ timeline: true
 - 🌟 `<pro>Table`: Added `Table` submit check automatically to check failed cell feature.
 - 🐞 `<pro>Table`: Fixed `Table` the scroll auto automatic sliding.
 - 🐞 `<pro>Table`: Fixed `Table` use inline mode the lookup auto pack up.
+- 🐞 `<pro>Table`: Modified the judgment mechanism of `useMouseBatchChoose`, and fixed the problem that the attribute behaves as true when global setting true and component setting false.
 - 🐞 `<pro>TextArea`: Fixed the problem that after setting required and resize properties in `Form` at the same time, the background color does not change along with the width and height.
 - 🐞 `<pro>Button`: Modified the loading mechanism to fix the problem that the query button does not enter the loading state in the Table.
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -23,8 +23,10 @@ timeline: true
 - 🌟 `<pro>Table`: 新增控制行内编辑器回车跳转下一行编辑器属性 `editorNextKeyEnterDown`。
 - 🐞 `<pro>Table`: 修复在 IE 浏览器下滑动条回弹问题。
 - 🐞 `<pro>Table`: 修复使用 inline 模式出现 lookup 自动收起问题。
+- 🐞 `<pro>Table`: 修改了useMouseBatchChoose的判定机制,修复了在全局设置true,组件设置false时属性表现为true的问题。
 - 🐞 `<pro>TextArea`: 修复在 Form 中同时设置了required 跟 resize 属性后，背景色不跟着宽高一起变化的问题。
 - 🐞 `<pro>Button`: 修改 loading 机制，修复 query 按钮在 Table 中不进入 loading 状态的问题。
+
 
 ## 0.8.67
 

--- a/components-pro/table/TableStore.tsx
+++ b/components-pro/table/TableStore.tsx
@@ -402,7 +402,13 @@ export default class TableStore {
   @computed
   get useMouseBatchChoose(): boolean {
     const { useMouseBatchChoose } = this.props;
-    return useMouseBatchChoose || getConfig('tableUseMouseBatchChoose') || false;
+    if (useMouseBatchChoose !== undefined) {
+      return useMouseBatchChoose;
+    }
+    if (getConfig('tableUseMouseBatchChoose') !== undefined) {
+      return getConfig('tableUseMouseBatchChoose');
+    }
+    return false;
   }
 
   @computed


### PR DESCRIPTION
…oose`, and fixed the problem that the attribute behaves as true when global setting true and component setting false.